### PR TITLE
Py3 and arch compatibility

### DIFF
--- a/pwnlib/elf/corefile.py
+++ b/pwnlib/elf/corefile.py
@@ -72,7 +72,7 @@ import os
 import socket
 import tempfile
 
-from six.moves import BytesIO, StringIO
+from six import BytesIO
 
 import elftools
 from elftools.common.py3compat import bytes2str
@@ -428,7 +428,7 @@ class Corefile(ELF):
 
         Corefiles can also be pulled from remote machines via SSH!
 
-        >>> s = ssh('travis', 'example.pwnme')
+        >>> s = ssh(host='example.pwnme', user='travis', password='demopass')
         >>> _ = s.set_working_directory()
         >>> elf = ELF.from_assembly(shellcraft.trap())
         >>> path = s.upload(elf.path)

--- a/pwnlib/util/fiddling.py
+++ b/pwnlib/util/fiddling.py
@@ -9,7 +9,7 @@ import re
 import os
 import six
 import string
-from six.moves import BytesIO
+from six import BytesIO
 
 from pwnlib.context import context
 from pwnlib.log import getLogger

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ install_requires     = ['paramiko>=1.15.2',
                         'psutil>=3.3.0',
                         'intervaltree',
                         'sortedcontainers<2.0', # See Gallopsled/pwntools#1154
+                        'sphinx==1.6.7',
                         'unicorn']
 
 # Check that the user has installed the Python development headers

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -64,14 +64,38 @@ setup_travis()
 
 setup_linux()
 {
-    sudo apt-get install -y software-properties-common openssh-server libncurses5-dev libncursesw5-dev openjdk-8-jre-headless
-    RELEASE="$(lsb-release -sr)"
-    if [[ "$RELEASE" < "16.04" ]]; then
-        sudo apt-add-repository --yes ppa:pwntools/binutils
-        sudo apt-get update
-        sudo apt-get install -y binutils-arm-linux-gnu binutils-mips-linux-gnu binutils-powerpc-linux-gnu
-    else
-        sudo apt-get install -y binutils-arm-linux-gnueabihf binutils-mips-linux-gnu binutils-powerpc-linux-gnu
+    declare -A osInfo;
+    osInfo[/etc/redhat-release]=yum
+    osInfo[/etc/arch-release]=pacman
+    osInfo[/etc/gentoo-release]=emerge
+    osInfo[/etc/SuSE-release]=zypp
+    osInfo[/etc/debian_version]=apt-get
+
+    for f in ${!osInfo[@]}
+    do
+        if [[ -f $f ]];then
+            PKG_MAN=${osInfo[$f]}
+            echo detected package manager $PKG_MAN
+        fi
+    done
+
+    if [ PKG_MAN = "apt-get" ]; then
+        sudo apt-get install -y software-properties-common openssh-server libncurses5-dev libncursesw5-dev openjdk-8-jre-headless
+        RELEASE="$(lsb-release -sr)"
+        if [[ "$RELEASE" < "16.04" ]]; then
+            sudo apt-add-repository --yes ppa:pwntools/binutils
+            sudo apt-get update
+            sudo apt-get install -y binutils-arm-linux-gnu binutils-mips-linux-gnu binutils-powerpc-linux-gnu
+        else
+            sudo apt-get install -y binutils-arm-linux-gnueabihf binutils-mips-linux-gnu binutils-powerpc-linux-gnu
+        fi
+    fi
+
+    if [ PKG_MAN = "pacman" ]; then
+        pacman -S openssh curses jre8-openjdk-headless bintuils arm-none-eabi-binutils yay
+        # TODO: binutils-mips-linux-gnu binutils-powerpc-linux-gnu are only in AUR
+        yay -S cross-mipsel-linux-gnu-binutils powerpc-linux-gnu-binutils
+        systemctl start sshd
     fi
 }
 


### PR DESCRIPTION
BytesIO is in six not in six.moves (py3 and py2 for six 
Tescode of corefile didn't use a password
Installing for arch working. gentoo, redhat, suse will follow
Current sphinx doesn't run tests